### PR TITLE
replace abandoned bundle heimrichhannot/contao-fieldpalette

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "contao/core-bundle": "^3.5.1 || ~4.1",
     "contao-community-alliance/composer-plugin": "~2.4 || ~3.0",
     "heimrichhannot/contao-tagsinput": "^2.1",
-    "heimrichhannot/contao-fieldpalette": "^1.4.5"
+    "heimrichhannot/contao-fieldpalette-bundle": "^0.6"
   },
   "autoload": {
     "classmap": [


### PR DESCRIPTION
Hello, on packagist you suggest to replace the bundle `"heimrichhannot/contao-fieldpalette"` with the bundle `"heimrichhannot/contao-fieldpalette-bundle"` but in the bundle 
`"heimrichhannot/contao-member_plus"` you still require the abandoned bundle.

Is there a reason for doing that? I tried replacing the abandoned bundle with the suggested one in a freshly installed contao 4.13 version and it worked for me.

Is there any functionality in the `"heimrichhannot/contao-member_plus"` that depends solely on the abandoned bundle or can you replace it with the suggested bundle?